### PR TITLE
fix hackcon video link to start at zero

### DIFF
--- a/index.html
+++ b/index.html
@@ -621,7 +621,7 @@
 								<a class="link" href="https://www.youtube.com/watch?v=LahACe0yvTg&t=138s"></a>
 							</div>
 							<div class="post_item_content">
-								<a class="title" href="https://www.youtube.com/watch?v=LahACe0yvTg&t=138s" >More than a one hit wonder</a>
+								<a class="title" href="https://www.youtube.com/watch?v=LahACe0yvTg&t" >More than a one hit wonder</a>
 								<ul class="post_item_inf">
 									<li><a >HackCon V</a> |</li>
 									<li><a >Philadephia, USA</a> |</li>


### PR DESCRIPTION
issue #1 - youtube link was originally pointing to 138s 
fixed.